### PR TITLE
Page structure

### DIFF
--- a/API/page_data.json
+++ b/API/page_data.json
@@ -1,0 +1,11 @@
+{
+	"pages" : {
+		"0_0_0" : {
+			"coords": [0,0,0],
+			"url": "../wanderpath/test_page.html",
+			"title": "a test page",
+			"author": "polyducks",
+			"desc": "A ponderous page ponders itself."
+		}
+	}
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- saved from url=(0024)https://wanderverse.org/ -->
+<html lang="en"><script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" type="image/png" href="data:image/png;base64,">
+<title>Wanderverse</title>
+<style>
+	body{
+		margin:1em auto;
+		max-width:40em;
+		padding:0 .62em;
+		font:1.2em/1.62 serif;
+		font-family: Palatino
+	}
+	h1,h2,h3 {
+		line-height:1.2;
+	}
+	@media print{
+		body{
+			max-width:none
+		}
+	}
+</style>
+</head><body><article>
+	<header>
+		<h1>Wanderverse</h1>
+		<h2>a realm of paths and pockets</h2>
+	</header>
+
+	<p>Welcome to Wanderverse. You've come upon a sunny meadow in the woods, full of wildflowers and fat, fuzzy bumblebees flying loops-de-loops. Here is the center, the start, the seed. Everyone must begin at the beginning.</p>
+
+	<p>Through the grass you see the overgrown, softened pattern of a labyrinth. Once upon a time someone shaped it. They mounded up the earth painstakingly. Who was it, who did that? Never mind for now.</p>
+
+	<ol><li><a href="https://www.sonyasupposedly.com/plumule-seed-fairy/">A seed drifts by</a></li>
+		<li>Spiral pacing</li>
+		<li>...</li>
+		<li>?</li></ol>
+
+	<p>Wanderverse is a fiction project released under the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal license</a>. As with old fairy stories passed down through generations, Wanderverse is freely available for anyone to use and adapt however they wish, including for profit.</p>
+
+	<p>This website exists as a directory of Wanderverse works released under the CC0 license. To contribute, please email your submission to <a href="mailto:wanderverse@sonya.email">wanderverse@sonya.email</a>.</p>
+	
+	<p>Wanderverse is a <a href="https://www.sonyasupposedly.com/">Sonya Supposedly</a> project.</p>
+
+</article></body></html>

--- a/wanderpath/test_page.html
+++ b/wanderpath/test_page.html
@@ -1,0 +1,39 @@
+<!-- Demo page to show file structure -->
+
+<style>
+	*{
+		box-sizing: border-box;
+		font-family: georgia;
+		font-style: italic;
+		color: #555;
+	}
+	body,HTML{
+		position: relative;
+		margin: 0;
+		padding: 0;
+		min-height: 100%;
+	}
+	body{
+		padding: 0 10px;
+	}
+	#poem{
+		margin: 0;
+		padding: 0;
+		display: inline-block;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		-o-transform: translateX(-50%)translateY(-50%);
+		-moz-transform: translateX(-50%)translateY(-50%);
+		-webkit-transform: translateX(-50%)translateY(-50%);
+		transform: translateX(-50%)translateY(-50%);
+		width: 20em;
+	}
+</style>
+
+<p id="poem">
+	I thought that here there would be more<br/>
+	another something to explore<br/>
+	there's only wall where I wanted door<br/>
+	all it says is 404<br/>
+</p>


### PR DESCRIPTION
Proposed layout for Wanderverse API and uploaded pages. Feel free to change things around or update the index.html with the latest version of the code.

The API is a basic JSON list of uploaded pages with a short description which can be used at a later point, either for a way to 'wander' the wanderverse in a visual manner, as a way of randomly serving pages for people to find, or as an index.

The pages are laid out on an X,Y,Z coordinate system to allow for a physical mapping of the pages, if that's something you might want.